### PR TITLE
Fixing issue where carousel doesn't show scrolling arrows

### DIFF
--- a/xooie/carousel.js
+++ b/xooie/carousel.js
@@ -281,7 +281,7 @@ define('xooie/carousel', ['jquery', 'xooie/base'], function($, Base) {
 
     Carousel.prototype.getRightLimit = function(){
         try {
-            var lastItem = this.content.children(':last'),
+            var lastItem = this.content.children(':visible:last'),
                 position = lastItem.position();
 
             if (position && typeof position.left !== 'undefined') {


### PR DESCRIPTION
When the last element of a list is display: none, the carousel won't
show the right arrow. This is because jQuery reports a left position for
that item of 0 which leads to the carousel thinking it is at its
rightmost limit.
