### PR TITLE
Fixing EventHandler's namespace support

### DIFF
--- a/xooie/event_handler.js
+++ b/xooie/event_handler.js
@@ -25,7 +25,7 @@ define('xooie/event_handler', ['jquery', 'xooie/helpers'], function($, helpers) 
   };
 
   function format(type, namespace) {
-    if (typeof namespace === 'undefined') {
+    if (!namespace) {
       return type;
     } else {
       return type + '.' + namespace;


### PR DESCRIPTION
This prevents EventHandler from appending a blank namespace to the event
type.
