### PR TITLE
Refactoring how constructors are called...

### DIFF
--- a/spec/addons/base.spec.js
+++ b/spec/addons/base.spec.js
@@ -53,27 +53,6 @@ require(['jquery', 'xooie/widgets/base', 'xooie/addons/base', 'xooie/shared'], f
 
                 expect(testVal).toBe(true);
             });
-
-            it('delays triggering the init event if there are constructors to be called', function(){
-                var testVal = false,
-                    AddonExtend = Addon.extend(function() { return true; });
-
-                this.el.on('xooie-addon-init', function(){
-                    testVal = true;
-                });
-
-                this.addon = new AddonExtend(this.widget);
-
-                expect(testVal).toBe(false);
-
-                waitsFor(function(){
-                    return this.addon._extendCount === null;
-                });
-
-                runs(function(){
-                    expect(testVal).toBe(true);
-                });
-            });
         });
 
         describe('When defining a new property...', function(){
@@ -127,14 +106,15 @@ require(['jquery', 'xooie/widgets/base', 'xooie/addons/base', 'xooie/shared'], f
         });
 
         describe('When extending the Addon...', function(){
-            it('calls the Shared extend method', function(){
-                spyOn(Shared, 'extend');
+            it('calls the Shared create method', function(){
+                spyOn(Shared, 'create');
 
-                var constructor = function(){};
+                var constructor = function(){},
+                    post_constructor = function(){};
 
-                Addon.extend(constructor);
+                Addon.extend(constructor, post_constructor);
 
-                expect(Shared.extend).toHaveBeenCalledWith(constructor, Addon);
+                expect(Shared.create).toHaveBeenCalledWith(constructor, post_constructor, Addon);
             });
         });
 

--- a/spec/shared.spec.js
+++ b/spec/shared.spec.js
@@ -74,39 +74,27 @@ require(['jquery', 'xooie/shared', 'xooie/widgets/base'], function($, Shared, Wi
     });
 
     describe('When extending the base module...', function(){
-        var constructor, Extended;
+        var constructor, post_constructor, Extended;
 
         beforeEach(function(){
             constructor = jasmine.createSpy('constructor');
+            post_constructor = jasmine.createSpy('post_constructor');
         });
 
-        it('sets the extendCount to 1 if extending Base', function(){
-            Extended = Shared.extend(constructor, Widget);
-
-            expect(Extended.prototype._extendCount).toBe(1);
-        });
-
-        it('increments the extendCount if an extended widget is extended', function(){
-            Extended = Shared.extend(constructor, Widget);
-
-            var Widget_Two = Extended.extend(constructor);
-
-            expect(Widget_Two.prototype._extendCount).toBe(2);
-        });
-
-        it('returns a new constructor that invokes the Base constructor and the passed constructor', function(){
-            Extended = Shared.extend(function() { constructor(); }, Widget);
+        it('returns a new constructor that invokes the Base constructor, post constructor, and the passed constructor', function(){
+            Extended = Shared.create(constructor, post_constructor, Widget);
 
             this.el = $('<div />');
 
             var w = new Extended(this.el);
 
             expect(constructor).toHaveBeenCalled();
+            expect(post_constructor).toHaveBeenCalled();
             expect(w.root().is(this.el)).toBe(true);
         });
 
         it('extends the new Widget with the parent widget methods', function(){
-            Extended = Shared.extend(function(){ constructor(); }, Widget);
+            Extended = Shared.create(constructor, post_constructor, Widget);
             var prop;
 
             for (prop in Widget) {
@@ -115,7 +103,7 @@ require(['jquery', 'xooie/shared', 'xooie/widgets/base'], function($, Shared, Wi
         });
 
         it('extends the new Widget prototype with the parent prototype', function(){
-            Extended = Shared.extend(function(){ constructor(); }, Widget);
+            Extended = Shared.create(constructor, post_constructor, Widget);
 
             var prop;
 

--- a/spec/widgets/base.spec.js
+++ b/spec/widgets/base.spec.js
@@ -87,53 +87,6 @@ require(['jquery', 'xooie/widgets/base', 'xooie/shared'], function($, Widget, Sh
         expect(testVal).toBe(true);
       });
 
-      it('delays triggering the init event if there are constructors to be called', function(){
-        var testVal = false,
-            element = $('<div />'),
-            WidgetExtend = Widget.extend(function() { return true; });
-
-        element.on('xooie-init', function(){
-          testVal = true;
-        });
-
-        this.widget = new WidgetExtend(element);
-
-        expect(testVal).toBe(false);
-
-        waitsFor(function(){
-          return this.widget._extendCount === null;
-        });
-
-        runs(function(){
-          expect(testVal).toBe(true);
-        });
-      });
-
-      it('delays loading addons if there are inherited constructors to be called', function(){
-        var testVal = false,
-            element = $('<div />'),
-            WidgetExtend = Widget.extend(function() { return true; }),
-            addon = function() {
-                testVal = true;
-            };
-
-        element.on('xooie-init', function(){
-          testVal = true;
-        });
-
-        this.widget = new WidgetExtend(element, [addon]);
-
-        expect(testVal).toBe(false);
-
-        waitsFor(function(){
-          return this.widget._extendCount === null;
-        });
-
-        runs(function(){
-          expect(testVal).toBe(true);
-        });
-      });
-
       it('binds an event handler to the initEvent that calls _applyRoles', function(){
         spyOn(this.widget, '_applyRoles');
 
@@ -289,14 +242,15 @@ require(['jquery', 'xooie/widgets/base', 'xooie/shared'], function($, Widget, Sh
     });
 
     describe('When extending the Widget...', function(){
-      it('calls the Shared extend method', function(){
-        spyOn(Shared, 'extend');
+      it('calls the Shared create method', function(){
+        spyOn(Shared, 'create');
 
-        var constructor = function(){};
+        var constructor = function(){},
+            post_constructor = function(){};
 
-        Widget.extend(constructor);
+        Widget.extend(constructor, post_constructor);
 
-        expect(Shared.extend).toHaveBeenCalledWith(constructor, Widget);
+        expect(Shared.create).toHaveBeenCalledWith(constructor, post_constructor, Widget);
       });
     });
 

--- a/xooie/addons/base.js
+++ b/xooie/addons/base.js
@@ -36,7 +36,7 @@ define('xooie/addons/base', ['jquery', 'xooie/shared'], function($, shared) {
  * Instantiating a new Addon associates the addon with the widget passed into the constructor.  The addon is
  * stored in the [[Xooie.Widget#addons]] collection.
  **/
-    var Addon = function(widget) {
+    var Addon = shared.create(function(widget) {
         var self = this;
 
         // Check to see if the module is defined:
@@ -59,25 +59,9 @@ define('xooie/addons/base', ['jquery', 'xooie/shared'], function($, shared) {
 
         // Reference the widget:
         this.widget(widget);
-
-        // Check to see if there are any additional constructors to call;
-        var initCheck = function(){
-            var i;
-
-            if (!self._extendCount || self._extendCount <= 0) {
-                self.widget().root().trigger(self.get('initEvent'));
-                self._extendCount = null;
-            } else {
-                setTimeout(initCheck, 0);
-            }
-        };
-
-        if (this._extendCount > 0) {
-            setTimeout(initCheck, 0);
-        } else {
-            initCheck();
-        }
-    };
+    }, function(widget) {
+      this.widget().root().trigger(this.get('initEvent'));
+    });
 
 /**
  * Xooie.Addon.defineReadOnly(name, defaultValue)
@@ -117,10 +101,10 @@ define('xooie/addons/base', ['jquery', 'xooie/shared'], function($, shared) {
  * Xooie.Addon.extend(constr) -> Addon
  * - constr (Function): The constructor for the new [[Xooie.Addon]] class.
  *
- * See [[Xooie.shared.extend]].
+ * See [[Xooie.shared.create]].
  **/
-    Addon.extend = function(constr){
-        return shared.extend(constr, this);
+    Addon.extend = function(constr, post_constr){
+        return shared.create(constr, post_constr, this);
     };
 
 /** internal
@@ -129,13 +113,6 @@ define('xooie/addons/base', ['jquery', 'xooie/shared'], function($, shared) {
  * Same as [[Xooie.Widget#_definedProps]].
  **/
     Addon.prototype._definedProps = [];
-
-/** internal
- * Xooie.Addon#_extendCount -> Integer | null
- *
- * Same as [[Xooie.Widget#_extendCount]].
- **/
-    Addon.prototype._extendCount = null;
 
 /** internal
  * Xooie.Addon#_widget -> Widget

--- a/xooie/widgets/base.js
+++ b/xooie/widgets/base.js
@@ -117,7 +117,7 @@ define('xooie/widgets/base', ['jquery', 'xooie/xooie', 'xooie/helpers', 'xooie/s
  * Instantiates a new Xooie widget, or returns an existing widget if it is already associated with the element passed.
  * Any addons passed into the constructor will be instantiated and added to the [[Xooie.Widget#addons]] collection.
  **/
-  Widget = function(element, addons) {
+  Widget = shared.create(function(element, addons) {
     var self = this;
 
     element = $(element);
@@ -141,41 +141,27 @@ define('xooie/widgets/base', ['jquery', 'xooie/xooie', 'xooie/helpers', 'xooie/s
 
     var id = cacheInstance(this);
 
+    element.attr('data-xooie-instance', id);
+
     this.set('id', id);
 
     this.set('root', element);
 
     element.addClass(this.get('className'))
            .addClass(this.get('instanceClass'));
+  }, function(element, addons) {
+    var i;
 
-    var initCheck = function(){
-      var i;
-
-      if (!self._extendCount || self._extendCount <= 0) {
-
-        if (typeof addons !== 'undefined') {
-          for (i = 0; i < addons.length; i+=1) {
-            new addons[i](self);
-          }
-        }
-        
-        element.attr('data-xooie-instance', id);
-
-        element.trigger(self.get('initEvent'));
-        self._extendCount = null;
-      } else {
-        setTimeout(initCheck, 0);
+    if (typeof addons !== 'undefined') {
+      for (i = 0; i < addons.length; i+=1) {
+        new addons[i](this);
       }
-    };
-
-    if (this._extendCount > 0) {
-      setTimeout(initCheck, 0);
-    } else {
-      initCheck();
     }
 
+    this.root().trigger(this.get('initEvent'));
+
     // new keyboardNavigation();
-  };
+  });
 
 /** internal
  * Xooie.Widget._renderMethods -> Object
@@ -280,10 +266,10 @@ define('xooie/widgets/base', ['jquery', 'xooie/xooie', 'xooie/helpers', 'xooie/s
  * Xooie.Widget.extend(constr) -> Widget
  * - constr (Function): The constructor for the new [[Xooie.Widget]] class.
  *
- * See [[Xooie.shared.extend]].
+ * See [[Xooie.shared.create]].
  **/
-  Widget.extend = function(constr){
-    return shared.extend(constr, this);
+  Widget.extend = function(constr, post_constr){
+    return shared.create(constr, post_constr, this);
   };
 
 /**
@@ -328,13 +314,6 @@ define('xooie/widgets/base', ['jquery', 'xooie/xooie', 'xooie/helpers', 'xooie/s
  * A collection of roles that have been defined for this class instance.
  **/
   Widget.prototype._definedRoles = [];
-
-/** internal, read-only
- * Xooie.Widget#_extendCount -> Integer | null
- *
- * Tracks the number of constructors that need to be called.
- **/
-  Widget.prototype._extendCount = null;
 
 //PROPERTY DEFINITIONS
 


### PR DESCRIPTION
This removes the need for asynchronous code in the base widget and addon
constructors. Also allows the constructors to "act normally" when an
element has already been initialized (the object returned from the base
constructor will be called from the constructor wrapper).
