### PR TITLE
Attempting to fix Xooie click capture issue

### DIFF
--- a/spec/dropdown.spec.js
+++ b/spec/dropdown.spec.js
@@ -58,7 +58,7 @@ require(['jquery', 'xooie/dropdown'], function($, Dropdown) {
 
                         expect(d.expand).toHaveBeenCalled();
                     });
-                    
+
                 });
 
                 it('binds the event to the document object if the string "document" is passed in as a selector', function(){
@@ -199,6 +199,24 @@ require(['jquery', 'xooie/dropdown'], function($, Dropdown) {
                 spyOn(d, 'collapse');
 
                 handle.trigger('blur');
+
+                expect(d.collapse).toHaveBeenCalledWith(0, {delay: 0, index: 0});
+            });
+        });
+
+        describe('When the forceCollapse event is triggered...', function(){
+            beforeEach(function(){
+                el = $('<div><div data-role="dropdown-handle"></div><div data-role="dropdown-content"></div></div>');
+
+                d = new Dropdown(el);
+            });
+
+            it('calls collapse', function(){
+                var handle = d.getHandle(0);
+
+                spyOn(d, 'collapse');
+
+                handle.trigger('forceCollapse', {delay: 0, index: 0});
 
                 expect(d.collapse).toHaveBeenCalledWith(0, {delay: 0, index: 0});
             });

--- a/xooie/dropdown.js
+++ b/xooie/dropdown.js
@@ -83,6 +83,10 @@ define('xooie/dropdown', ['jquery', 'xooie/base'], function($, Base) {
 
                 $(this).attr('aria-selected', false);
                 self.getExpander(index).attr('aria-hidden', true);
+            },
+
+            forceCollapse: function(event, data) {
+                self.collapse(data.index, data);
             }
         }, this.options.dropdownHandleSelector);
 


### PR DESCRIPTION
If there are multiple Gallery Rows on a page and you click an item in one row, then click an item in another row, and then click a button in that item that does something on the page (like launch a Flash video player) Xooie will capture all clicks & preventDefault, rendering the mouse useless.

These changes attempt to do 2 things:
1. Always collapse the dropdown if 'collapse' is called (should take care of the multiple Gallery Row issue)
2. Expose a 'forceCollapse' event that can be triggered & calls collapse (because I've seen that sometimes, for reasons I'm not quite sure, collapse isn't called)
